### PR TITLE
Fix errors with cddlib 0.94h

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,9 +31,11 @@ source:
     - patches/fix_cache_file_length.patch
     # undo upgrade to an unreleased PARI
     - patches/use-sages-ratpoints.patch
+    # work around changed cdd output in version 094h
+    - patches/u1-version-cddlib-094h.patch
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   skip: true  # [py3k and py<36]
   features:

--- a/recipe/patches/u1-version-cddlib-094h.patch
+++ b/recipe/patches/u1-version-cddlib-094h.patch
@@ -1,0 +1,29 @@
+Description: Use cddlib version 094h
+Author: Ximin Luo <infinity0@debian.org>
+Forwarded: TODO
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/sage/src/sage/geometry/polyhedron/backend_cdd.py
++++ b/sage/src/sage/geometry/polyhedron/backend_cdd.py
+@@ -286,7 +286,9 @@
+             else:
+                 n_cdd=n;
+             self._V_adjacency_matrix = matrix(ZZ, n, n, 0)
+-            expect_in_cddout('begin')
++            if not find_in_cddout('begin'):
++                raise ValueError('Error while parsing cdd output: could not '
++                                 'find "begin" after "Vertex graph"')
+             l = cddout.pop(0).split()
+             assert int(l[0]) == n_cdd, "Not enough V-adjacencies in cdd output?"
+             for i in range(n_cdd):
+@@ -309,7 +311,9 @@
+         if find_in_cddout('Facet graph'):
+             n = len(self._Hrepresentation);
+             self._H_adjacency_matrix = matrix(ZZ, n, n, 0)
+-            expect_in_cddout('begin')
++            if not find_in_cddout('begin'):
++                raise ValueError('Error while parsing cdd output: could not '
++                                 'find "begin" after "Facet graph"')
+             l = cddout.pop(0).split()
+             assert int(l[0]) == n, "Not enough H-adjacencies in cdd output?"
+             for i in range(n):


### PR DESCRIPTION
this might be good enough for 0.94i as well. If not, then we also have to update the sage recipe.