### PR TITLE
Remove NetworkX patch from series file

### DIFF
--- a/recipe/patches/series
+++ b/recipe/patches/series
@@ -14,4 +14,3 @@ sympy-12.patch
 25345.patch
 25786.patch
 26434.patch
-26326.patch


### PR DESCRIPTION
this is only used for automatic testing on GitLab it does not have any effect
on the conda package.